### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using LIteLLM

### DIFF
--- a/llm-server/app.py
+++ b/llm-server/app.py
@@ -4,7 +4,7 @@ import requests
 import warnings
 from flask import Flask, request
 from langchain.chains.openai_functions import create_structured_output_chain
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 from langchain.prompts import ChatPromptTemplate
 from langchain.utilities.openapi import OpenAPISpec
 
@@ -56,7 +56,7 @@ def handle():
         warnings.warn(str(e))
         json_output = None
 
-    llm = ChatOpenAI(model="gpt-3.5-turbo-0613", temperature=0)
+    llm = ChatLiteLLM(model="gpt-3.5-turbo-0613", temperature=0)
 
     if json_output is None:
         prompt_msgs = non_api_base_prompt(base_prompt, text)

--- a/llm-server/requirements.txt
+++ b/llm-server/requirements.txt
@@ -29,6 +29,7 @@ joblib==1.3.1
 langchain==0.0.236
 langcodes==3.3.0
 langsmith==0.0.10
+litellm>=0.1.574
 manifest-ml==0.0.1
 MarkupSafe==2.1.3
 marshmallow==3.19.0


### PR DESCRIPTION
This PR adds support for 50+ models with a standard I/O interface using: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```