### PR TITLE
Unifying openapi chain with api flows

### DIFF
--- a/llm-server/utils/detect_multiple_intents.py
+++ b/llm-server/utils/detect_multiple_intents.py
@@ -1,0 +1,39 @@
+import re
+import json
+from typing import Dict, List, Union
+
+
+def hasMultipleIntents(user_input: str) -> bool:
+    # Keywords for multiple questions
+    question_keywords = [
+        "and",
+        "also",
+        "in addition",
+        "moreover",
+        "furthermore",
+        "besides",
+        "additionally",
+        "another question",
+        "second question",
+        "next, ask",
+        "thirdly",
+        "finally",
+        "lastly",
+    ]
+
+    # Check for question keywords
+    question_pattern = "|".join(re.escape(keyword) for keyword in question_keywords)
+    question_matches = [
+        match.group()
+        for match in re.finditer(question_pattern, user_input, re.IGNORECASE)
+    ]
+
+    print(f"Found {question_matches} in the following input: {user_input}")
+    return bool(question_matches)
+
+
+# user_input = (
+#     "I want to fetch data from API A and also, can you answer another question?"
+# )
+# result = hasMultipleIntents(user_input)
+# print(json.dumps(result, indent=2))


### PR DESCRIPTION
```markdown
The bot will make an API call to the same API. The LLM can then decide whether to use [OpenAPI Chain](https://api.python.langchain.com/en/latest/agents/langchain.agents.agent_toolkits.openapi.spec.ReducedOpenAPISpec.html#langchain.agents.agent_toolkits.openapi.spec.ReducedOpenAPISpec) or to use one of the predefined flows using our flows editor.
```
