### PR TITLE
support multi-language layout fonts automatically.

### DIFF
--- a/dashboard/app/fonts.ts
+++ b/dashboard/app/fonts.ts
@@ -1,0 +1,17 @@
+import { Cairo, Open_Sans } from "next/font/google";
+
+export const cairoFont = Cairo({
+    subsets: ["arabic"],
+    weight: ["400", "500", "600", "700", "800"],
+    variable: '--cairo-font',
+    adjustFontFallback: false,
+    display: "fallback",
+})
+export const opensansFont = Open_Sans({
+    subsets: ["latin"],
+    weight: ["400", "500", "600", "700", "800"],
+    variable: '--opensans-font',
+    fallback: ["var(--cairo-font)"],
+    adjustFontFallback: false,
+    display: "fallback",
+});

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 import "./globals.css";
 import type { Metadata } from "next";
-import { Open_Sans } from "next/font/google";
 import { Tv2 } from "lucide-react";
 import { IS_DEV } from "@/lib/consts";
 import { SearchModal } from "./(main)/_parts/SearchModal";
@@ -11,13 +10,7 @@ import { Toaster } from "@/components/ui/sonner"
 import { HandleOnComplete } from "@/lib/router-events";
 import { TopLoader } from "@/lib/Toploader";
 import { JotaiProvider } from "./jotai-provider";
-
-const opensans = Open_Sans({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700", "800"],
-  fallback: ["Roboto", "sans-serif"],
-  preload: true,
-});
+import { cairoFont, opensansFont } from "./fonts";
 
 export const metadata: Metadata = {
   title: "OpenCopilot",
@@ -34,10 +27,14 @@ export default function RootLayout({
         <html lang="en">
           <body
             className={cn(
-              opensans.className,
+              cairoFont.variable,
+              opensansFont.variable,
               "h-svh min-h-svh max-h-svh w-svw overflow-hidden scroll-smooth bg-background text-accent-foreground antialiased",
               IS_DEV && "debug-screens",
             )}
+            style={{
+              fontFamily: 'var(--opensans-font),var(--cairo-font),ui-sans-serif,system-ui,sans-serif'
+            }}
           >
             {children}
             {/* browser too small message */}


### PR DESCRIPTION
Added support for Arabic font instead of the ugly fallback relying on the fallback mechanism of the CSS font family property 
this will apply `Cairo` font automatically to non-english letters.
as in the screenshot some text were rendered in `Open_Sans` font and the other in `Cairo` font


![image](https://github.com/openchatai/OpenCopilot/assets/76843311/04fc9264-b75a-4b76-b5cd-4674e01493b0)
