### PR TITLE
[Feat] Socket scale using ip-hash algo

### DIFF
--- a/container_config/nginx.conf
+++ b/container_config/nginx.conf
@@ -44,9 +44,7 @@ http {
         }
     }
     upstream socket_servers {
-    ip_hash;
-    server llm-server:8002;
-    server llm-server:8002;
-    server llm-server:8002;
-  }
+      ip_hash; # Use IP hash to ensure that the same client is always connected to the same server
+      server llm-server:8002;
+    }
 }

--- a/container_config/nginx.conf
+++ b/container_config/nginx.conf
@@ -9,7 +9,7 @@ http {
         listen 80;
 
         location /socket.io {
-            proxy_pass http://llm-server:8002/socket.io;  # Replace "your-server-url" with your actual server URL
+            proxy_pass http://socket_servers/socket.io;  # Replace "your-server-url" with your actual server URL
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_set_header Upgrade $http_upgrade;
@@ -43,4 +43,10 @@ http {
             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
         }
     }
+    upstream socket_servers {
+    ip_hash;
+    server llm-server:8002;
+    server llm-server:8002;
+    server llm-server:8002;
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,8 @@ services:
       - opencopilot-net
     env_file:
       - llm-server/.env
-    ports:
-      - 8002:8002
-      - 5678:5678
+    deploy:
+      replicas: 3 # Increased number of replicas
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
This PR introduce the llm-server to scale horizontally by having multiple replicas. 

**The approach**
For only socket connections nginx will remember the request ip and redirect all relevant response to the same ip. 

**Using Nginx**
1. REST api requests are getting evenly distributed among available servers. 
2. Socket connections stay persistent for ongoing conversation. 

**Warning:** 
If you wanna test this locally, you will notice that one server (eg. server1) is taking responsibility for multiple chatbots. This is because Nginx is remembering your ip-address and will redirect all socket request to server1. So even-if you're chatting with 100 chatbots in a same time from same ip-address, it will redirect all the requests to that one server. 